### PR TITLE
8 Redesign and optimize long and short beacon plots

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-globe.gl": "2.36.0",
     "react-range": "^1.10.0",
     "react-scripts": "^0.0.0",
-    "recharts": "3.3.0",
+    "recharts": "3.7.0",
     "satellite.js": "6.0.1",
     "tailwindcss": "^4.1.14",
     "three": "0.180.0",

--- a/src/components/LongPlots.jsx
+++ b/src/components/LongPlots.jsx
@@ -1,15 +1,15 @@
-import  { useEffect, useState } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area,} from 'recharts';
+import { useEffect, useState } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area, } from 'recharts';
 import moment from 'moment';
-import {getdatagraphsLong} from '../scripts/downloaders.ts'
+import { getdatagraphsLong } from '../scripts/downloaders.ts'
 import { useStore } from '@nanostores/react';
 import { timeDataStore } from '../scripts/timeData.ts';
 
 function LongPlots(props) {
 
     const $timeDataStore = useStore(timeDataStore);
-    const {range: storeRange} = $timeDataStore;
-    const [listofvals, setlistofvals]=useState({})
+    const { range: storeRange } = $timeDataStore;
+    const [listofvals, setlistofvals] = useState({})
     //console.log(decoder.decoder_short_beacon('8A82A4A89040E0A6A082868A406103F0000003E6080850E903510006050C'))
 
     useEffect(() => {
@@ -25,87 +25,85 @@ function LongPlots(props) {
 
         // Call the async function
         fetchData();
-      },[storeRange]);
-    
-    
+    }, [storeRange]);
+
+
     return (
-        <div>
-        <footer style={{display:'flex'}}>
-        <ResponsiveContainer width='33%' minHeight={200} >
+        <div class="flex  gap-4 justify-center  p-2">
             <LineChart
-            data={listofvals.gyrolarge}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
+                style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                responsive
+                data={listofvals.gyrolarge}
+                margin={{
+                    top: 5,
+                    right: 0,
+                    left: 0,
+                    bottom: 5,
+                }}
             >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff" 
-            tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-            domain={['auto', 'auto']}
-            scale="time"
-            type='number' />
-            <YAxis stroke="#fff" domain={[-300,300]}/>
-            <Tooltip />
-            <Legend />
-            <Line type="monotone" dataKey="gyrox" stroke="#d68165" strokeWidth={2}/>
-            <Line type="monotone" dataKey="gyroy" stroke="#65D681" strokeWidth={2}/>
-            <Line type="monotone" dataKey="gyroz" stroke="#8165D6" strokeWidth={2}/>
+                <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                <XAxis dataKey="name" stroke="#fff"
+                    tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                    domain={['auto', 'auto']}
+                    scale="time"
+                    type='number' />
+                <YAxis stroke="#fff" domain={[-300, 300]} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="gyrox" stroke="#d68165" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="gyroy" stroke="#65D681" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="gyroz" stroke="#8165D6" strokeWidth={2} dot={false} />
             </LineChart>
-        </ResponsiveContainer>
-        <ResponsiveContainer width='33%' minHeight={200} >
             <LineChart
-            data={listofvals.chargecapacity}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
+                style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                responsive
+                data={listofvals.chargecapacity}
+                margin={{
+                    top: 5,
+                    right: 0,
+                    left: 0,
+                    bottom: 5,
+                }}
             >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff"  
-            tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-            domain={['auto', 'auto']}
-            scale="time"
-            type='number'/>
-            <YAxis stroke="#fff"/>
-            <Tooltip />
-            <Legend />
-            <Line type="monotone" dataKey="BankChar1" stroke="#8884d8" strokeWidth={2} />
-            <Line type="monotone" dataKey="BankChar2" stroke="#82ca9d" strokeWidth={2}/>
+                <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                <XAxis dataKey="name" stroke="#fff"
+                    tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                    domain={['auto', 'auto']}
+                    scale="time"
+                    type='number' />
+                <YAxis stroke="#fff" />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="BankChar1" stroke="#8884d8" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="BankChar2" stroke="#82ca9d" strokeWidth={2} dot={false} />
             </LineChart>
-        </ResponsiveContainer>
-        <ResponsiveContainer width='33%' minHeight={200} >
             <LineChart
-            data={listofvals.batvolts}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
+                style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                responsive
+                data={listofvals.batvolts}
+                margin={{
+                    top: 5,
+                    right: 0,
+                    left: 0,
+                    bottom: 5,
+                }}
             >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff"  
-            tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-            domain={['auto', 'auto']}
-            scale="time"
-            type='number'/>
-            <YAxis stroke="#fff"/>
-            <Tooltip />
-            <Legend />
-            <Line type="monotone" dataKey="BankVolt1" stroke="#8884d8" strokeWidth={2} />
-            <Line type="monotone" dataKey="BankVolt2" stroke="#82ca9d" strokeWidth={2}/>
+                <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                <XAxis dataKey="name" stroke="#fff"
+                    tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                    domain={['auto', 'auto']}
+                    scale="time"
+                    type='number' />
+                <YAxis stroke="#fff" />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="BankVolt1" stroke="#8884d8" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="BankVolt2" stroke="#82ca9d" strokeWidth={2} dot={false} />
             </LineChart>
-        </ResponsiveContainer>
-        </footer>
         </div>
-        
-        
+
+
     );
-  }
+}
 
 export default LongPlots

--- a/src/components/ShortPlots.jsx
+++ b/src/components/ShortPlots.jsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import { XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area,} from 'recharts';
+import { XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area, } from 'recharts';
 import moment from 'moment';
-import {getdatagraphsShort} from '../scripts/downloaders.ts'
+import { getdatagraphsShort } from '../scripts/downloaders.ts'
 import { useStore } from '@nanostores/react';
 import { timeDataStore } from '../scripts/timeData.ts';
 
 function ShortPlots(props) {
 
     const $timeDataStore = useStore(timeDataStore);
-    const {range: storeRange} = $timeDataStore;
-    
-    const [listofvals, setlistofvals]=useState({})
+    const { range: storeRange } = $timeDataStore;
+
+    const [listofvals, setlistofvals] = useState({})
 
     useEffect(() => {
         console.log('Store date changed:', storeRange);
-        
+
         const fetchData = async () => {
             try {
                 const data = await getdatagraphsShort(storeRange[0], storeRange[1]);
@@ -28,98 +28,91 @@ function ShortPlots(props) {
         // Call the async function
         fetchData();
 
-      },[storeRange]);
-    
+    }, [storeRange]);
+
     return (
         <div>
-        
-        
-        <main >
+            <main class=" p-4">
+                <AreaChart
+                    style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                    responsive
+                    data={listofvals.tempshorts}
+                    margin={{
+                        top: 5,
+                        right: 0,
+                        left: 0,
+                        bottom: 5,
+                    }}
+                >
+                    {/* <CartesianGrid strokeDasharray="4 3" stroke="#fff" fill='#ffffff20' /> */}
+                    <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                    <XAxis dataKey="name" stroke="#fff"
+                        tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                        domain={['auto', 'auto']}
+                        scale="time"
+                        type='number'
+                    />
+                    <YAxis stroke="#fff" />
+                    <Tooltip />
+                    <Legend />
+                    <Area type="monotone" dataKey="pat" stroke="#8884d8" />
+                    <Area type="monotone" dataKey="smpt" stroke="#82ca9d" />
+                </AreaChart>
+                <AreaChart
+                    style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                    responsive
+                    data={listofvals.voltshors}
+                    margin={{
+                        top: 5,
+                        right: 0,
+                        left: 0,
+                        bottom: 5,
+                    }}
+                >
+                    {/* <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20' /> */}
+                    <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                    <XAxis dataKey="name" stroke="#fff"
+                        tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                        domain={['auto', 'auto']}
+                        scale="time"
+                        type='number' />
+                    <YAxis stroke="#fff" />
+                    <Tooltip />
+                    <Legend />
+                    <Area type="monotone" dataKey="v5v" stroke='#f78981' fill='#a54d4d' />
+                    <Area type="monotone" dataKey="v3v3" stroke="#70f170" fill='#4f9b38ff' />
 
-       
-        <ResponsiveContainer width='20%' minHeight={200} >
-            <AreaChart
-            //className='Grafica'
-            // width={100}
-            // height={300}
-            data={listofvals.tempshorts}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
-            >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff"  
-            tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-            domain={['auto', 'auto']}
-            scale="time"
-            type='number'
-            />
-            <YAxis stroke="#fff"/>
-            <Tooltip />
-            <Legend />
-            <Area type="monotone" dataKey="pat" stroke="#8884d8" />
-            <Area type="monotone" dataKey="smpt" stroke="#82ca9d" />
-            </AreaChart>
-        </ResponsiveContainer>
-        <ResponsiveContainer width='20%' minHeight={200} >
-            <AreaChart
-            //className='Grafica'
-            // width={100}
-            // height={300}
-            data={listofvals.voltshors}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
-            >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff"  
-             tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-             domain={['auto', 'auto']}
-             scale="time"
-             type='number'/>
-            <YAxis stroke="#fff"/>
-            <Tooltip />
-            <Legend />
-            <Area type="monotone" dataKey="v5v" stroke='#f78981' fill='#a54d4d' />
-            <Area type="monotone" dataKey="v3v3" stroke="#70f170" fill='#4f9b38ff'  />
-            
-            </AreaChart>
-        </ResponsiveContainer>
-        <ResponsiveContainer width='20%' minHeight={200} >
-            <AreaChart
-            data={listofvals.currentshors}
-            margin={{
-                top: 5,
-                right: 30,
-                left: 20,
-                bottom: 5,
-            }}
-            >
-            <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20'/>
-            <XAxis dataKey="name" stroke="#fff"  
-             tickFormatter = {(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
-             domain={['auto', 'auto']}
-             scale="time"
-             type='number'/>
-            <YAxis stroke="#fff"/>
-            <Tooltip />
-            <Legend />
-            <Area type="monotone" dataKey="c3v3" stroke="#70f170" fill='#4f9b38ff' activeDot={{ r: 8 }} />
-            <Area type="monotone" dataKey="c5v" stroke='#f78981' fill='#a54d4d' />
-            
-            </AreaChart>
-        </ResponsiveContainer>
-        </main>
+                </AreaChart>
+                <AreaChart
+                    style={{ width: '100%', maxWidth: '500px', height: '100%', maxHeight: '20vh', aspectRatio: 1.618 }}
+                    responsive
+                    data={listofvals.currentshors}
+                    margin={{
+                        top: 5,
+                        right: 0,
+                        left: 0,
+                        bottom: 5,
+                    }}
+                >
+                    {/* <CartesianGrid strokeDasharray="3 3" stroke="#fff" fill='#ffffff20' /> */}
+                    <CartesianGrid strokeDasharray="1 0" stroke="#ffffff2f" fill='#7e7e7e20' vertical={true} horizontal={true} />
+                    <XAxis dataKey="name" stroke="#fff"
+                        tickFormatter={(timestamp) => moment(timestamp).format('DD/MM/YY HH:mm')}
+                        domain={['auto', 'auto']}
+                        scale="time"
+                        type='number' />
+                    <YAxis stroke="#fff" />
+                    <Tooltip />
+                    <Legend />
+                    <Area type="monotone" dataKey="c3v3" stroke="#70f170" fill='#4f9b38ff' activeDot={{ r: 8 }} />
+                    <Area type="monotone" dataKey="c5v" stroke='#f78981' fill='#a54d4d' />
+
+                </AreaChart>
+            </main>
         </div>
-        
-        
+
+
     );
-  }
+}
 
 export default ShortPlots


### PR DESCRIPTION
- Upgrade `recharts` dependency from 3.3.0 to 3.7.0.
- Refactor `LongPlots` and `ShortPlots` layouts:
  - Replace `ResponsiveContainer` with flexbox containers and inline styles for better responsiveness and aspect ratio control.
  - Standardize chart dimensions (max-width: 500px, aspect-ratio: 1.618).
- Update chart styling:
  - Modify `CartesianGrid` stroke and dash array for cleaner visuals.
  - Remove dots from `LineChart` components in `LongPlots` to reduce visual clutter and improve rendering performance.
  - Adjust chart margins to maximize available space.
- Clean up formatting and imports in component files.